### PR TITLE
update factory signature & small fixes

### DIFF
--- a/src/main/java/com/bmwcarit/barefoot/road/BfmapReader.java
+++ b/src/main/java/com/bmwcarit/barefoot/road/BfmapReader.java
@@ -47,11 +47,7 @@ public class BfmapReader implements RoadReader {
 
     @Override
     public boolean isOpen() {
-        if (reader != null) {
-            return true;
-        } else {
-            return false;
-        }
+        return reader != null;
     }
 
     @Override

--- a/src/main/java/com/bmwcarit/barefoot/road/PostGISReader.java
+++ b/src/main/java/com/bmwcarit/barefoot/road/PostGISReader.java
@@ -46,6 +46,7 @@ public class PostGISReader extends PostgresSource implements RoadReader {
     private HashSet<Short> exclusions = null;
     private Polygon polygon = null;
     private ResultSet result_set = null;
+    private boolean isReaderOpen = false;
 
     /**
      * Constructs {@link PostGISReader} object.
@@ -66,6 +67,11 @@ public class PostGISReader extends PostgresSource implements RoadReader {
     }
 
     @Override
+    public boolean isOpen() {
+        return isReaderOpen;
+    }
+
+    @Override
     public void open() throws SourceException {
         logger.info("open reader (standard)");
         open(null, null);
@@ -75,6 +81,7 @@ public class PostGISReader extends PostgresSource implements RoadReader {
     public void open(Polygon polygon, HashSet<Short> exclusions) throws SourceException {
         logger.info("open reader (parameterized)");
         super.open();
+        this.isReaderOpen = true;
         this.exclusions = exclusions;
         this.polygon = polygon;
     }

--- a/src/main/java/com/bmwcarit/barefoot/road/RoadMapReader.java
+++ b/src/main/java/com/bmwcarit/barefoot/road/RoadMapReader.java
@@ -1,13 +1,12 @@
 package com.bmwcarit.barefoot.road;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 
 import com.esri.core.geometry.Polygon;
 import com.esri.core.geometry.SpatialReference;
 import com.esri.core.geometry.GeometryEngine;
-
+import com.bmwcarit.barefoot.roadmap.Road;
 import com.bmwcarit.barefoot.roadmap.RoadMap;
 import com.bmwcarit.barefoot.util.SourceException;
 

--- a/src/main/java/com/bmwcarit/barefoot/road/RoadMapReader.java
+++ b/src/main/java/com/bmwcarit/barefoot/road/RoadMapReader.java
@@ -31,7 +31,7 @@ public class RoadMapReader implements RoadReader{
 	
     @Override
     public boolean isOpen() {
-        return (iterator != null);
+        return iterator != null;
     }
 
     @Override

--- a/src/main/java/com/bmwcarit/barefoot/road/RoadReaderFactory.java
+++ b/src/main/java/com/bmwcarit/barefoot/road/RoadReaderFactory.java
@@ -6,7 +6,6 @@ import com.bmwcarit.barefoot.util.Tuple;
 import com.bmwcarit.barefoot.roadmap.RoadMap;
 
 public class RoadReaderFactory {
-	
 	/**
 	 * Creates a RoadReader that can read BaseRoad objects from a PostgreSQL/PostGIS database
 	 * 
@@ -21,7 +20,7 @@ public class RoadReaderFactory {
 	 */
 	public RoadReader createPostGISReader(String host, int port, String database, String table, String user,
 			String password, Map<Short, Tuple<Double, Integer>> config) {
-		return new PostGISReader(host, port, database, table, user, password, config)
+		return new PostGISReader(host, port, database, table, user, password, config);
 	}
 	
 	/**

--- a/src/main/java/com/bmwcarit/barefoot/road/RoadReaderFactory.java
+++ b/src/main/java/com/bmwcarit/barefoot/road/RoadReaderFactory.java
@@ -18,7 +18,7 @@ public class RoadReaderFactory {
 	 * @param config Configuration of road type data for RoadReader to read
 	 * @return A RoadReader that reads BaseRoad objects from a PostgreSQL/PostGIS database (PostGISReader)
 	 */
-	public RoadReader createPostGISReader(String host, int port, String database, String table, String user,
+	public RoadReader getRoadReader(String host, int port, String database, String table, String user,
 			String password, Map<Short, Tuple<Double, Integer>> config) {
 		return new PostGISReader(host, port, database, table, user, password, config);
 	}
@@ -29,7 +29,7 @@ public class RoadReaderFactory {
 	 * @param path The path to the barefoot map file to read.
 	 * @return A RoadReader that reads BaseRoad objects from a barefoot map file.
 	 */
-	public RoadReader createBfmapReader(String path) {
+	public RoadReader getRoadReader(String path) {
 		return new BfmapReader(path);
 	}
 	
@@ -39,7 +39,7 @@ public class RoadReaderFactory {
 	 * @param src Source of BaseRoad objects to read from.
 	 * @return A RoadReader that reads BaseRoad objects from a RoadMap.
 	 */
-	public RoadReader createRoadMapReader(RoadMap src) {
+	public RoadReader getRoadReader(RoadMap src) {
 		return new RoadMapReader(src);
 	}
 }

--- a/src/main/java/com/bmwcarit/barefoot/roadmap/Loader.java
+++ b/src/main/java/com/bmwcarit/barefoot/roadmap/Loader.java
@@ -114,7 +114,7 @@ public class Loader {
             logger.info("load map from file {}", file.getAbsolutePath());
             
             RoadReaderFactory factory = new RoadReaderFactory();
-            BfmapReader bfFileReader = factory.createBfmapReader(file.getAbsolutePath());
+            BfmapReader bfFileReader = (BfmapReader) factory.getRoadReader(file.getAbsolutePath());
             map = RoadMap.Load(bfFileReader);
         }
 
@@ -199,7 +199,7 @@ public class Loader {
         }
         
         RoadReaderFactory factory = new RoadReaderFactory();
-        PostGISReader result = (PostGISReader)factory.createPostGISReader(host, port, database, table, user, password, config);
+        PostGISReader result = (PostGISReader) factory.getRoadReader(host, port, database, table, user, password, config);
         return result;
     }
 }


### PR DESCRIPTION
## unified getter
This update allows us to unify the getter so that after the factory initialization  
```java
RoadReaderFactory factory = new RoadReaderFactory();
```
instead of doing  
```java
BfmapReader bfFileReader = (BfmapReader) factory.createBfmapReader(file.getAbsolutePath());
```
we do  
```java
BfmapReader bfFileReader = (BfmapReader) factory.getRoadReader(file.getAbsolutePath());
```
This way the factory can call the single method no matter the road reader type as we expose single getter name.

## overloading
Since we are overloading the getter and all three types have different args, we don't even need to check for in the getter
```java
// RoadReaderTypes.java
package com.bmwcarit.barefoot.road;

enum RoadReaderTypes {
	PostGIS,
	Bfmap,
	RoadMap,
}
```
```java
// RoadReaderFactory.java
package com.bmwcarit.barefoot.road;

import java.util.Map;

import com.bmwcarit.barefoot.util.Tuple;
import com.bmwcarit.barefoot.roadmap.RoadMap;

public class RoadReaderFactory {
	public RoadReader getRoadReader(RoadReaderType roadReaderType) {
		switch(roadReaderType) {
			case PostGIS:
				return new PostGISReader(/* args */);
			case Bfmap:
				return new BfmapReader(/* args */);
			case RoadMap:
				return new RoadMapReader(/* args */);
		}
	}
}
```